### PR TITLE
Fix detail

### DIFF
--- a/app/controllers/account_books_controller.rb
+++ b/app/controllers/account_books_controller.rb
@@ -69,10 +69,10 @@ class AccountBooksController < ApplicationController
   end
 
   def response_message(access_token)
-    if @access_token.response.class == Net::HTTPOK
+    if access_token.response.class == Net::HTTPOK
       flash[:success] = "#{self.action_name} account record is successful."
     else
-      flash[:alert] = @access_token.response
+      flash[:alert] = access_token.response
     end
   end
 

--- a/app/controllers/account_books_controller.rb
+++ b/app/controllers/account_books_controller.rb
@@ -36,7 +36,7 @@ class AccountBooksController < ApplicationController
   end
 
   def authenticated_user
-    return if session[:request_token] && session[:request_secret]
+    return if session[:access_token] && session[:access_secret]
     redirect_to root_path
     flash[:alert] = "Sign in is required."
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,13 +8,6 @@ class SessionsController < ApplicationController
     redirect_to @request_token.authorize_url(oauth_callback: CALLBACK_URL)
   end
 
-  def signout
-    session[:request_token] = nil
-    session[:request_secret] = nil
-    redirect_to root_path
-    flash[:notice] = "Sign out is successfull."
-  end
-
   def callback
     if session[:request_token] && params[:oauth_verifier]
       @oauth_verifier = params[:oauth_verifier]
@@ -29,6 +22,14 @@ class SessionsController < ApplicationController
       flash[:alert] = "Something went wrong ..."
     end
   end
+
+  def signout
+    session[:access_token] = nil
+    session[:access_secret] = nil
+    redirect_to root_path
+    flash[:notice] = "Sign out is successfull."
+  end
+
 
   private
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
     "199"=>"Other"}
 
   def signin_user?
-    if session[:request_token] && session[:request_secret]
+    if session[:access_token] && session[:access_secret]
       true
     end
   end


### PR DESCRIPTION
response_messageメソッドの中の変数がインスタンスメソッドになっていたため修正

アクセストークンとリクエストトークンの理解が誤っていたためコントローラ内のセッション管理を修正