### PR TITLE
fix tab indent in Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,13 +21,13 @@ gem 'toastr-rails'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-	gem 'factory_bot_rails', '~> 4.10.0'
-	gem 'pry-rails'
-	gem 'rspec-rails', '~> 3.6.0'
-	gem 'rspec-core'
-	gem 'rspec_junit_formatter'
+  gem 'factory_bot_rails', '~> 4.10.0'
+  gem 'pry-rails'
+  gem 'rspec-rails', '~> 3.6.0'
+  gem 'rspec-core'
+  gem 'rspec_junit_formatter'
   gem 'webmock'
-	gem 'dotenv-rails'
+  gem 'dotenv-rails'
 end
 
 group :development do
@@ -35,12 +35,12 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-	gem 'spring-commands-rspec'
+  gem 'spring-commands-rspec'
 end
 
 group :test do
-	gem 'launchy'
+  gem 'launchy'
   gem 'capybara', '~> 2.13'
-	gem 'chromedriver-helper'
+  gem 'chromedriver-helper'
   gem 'selenium-webdriver'
 end


### PR DESCRIPTION
vimの設定がindent設定が誤っておりGemfile内のインデントがずれていたので修正致しました。